### PR TITLE
networking.k8s.io/v1 for Ingress kind

### DIFF
--- a/charts/kube-oidc-proxy/Chart.yaml
+++ b/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/charts/kube-oidc-proxy/Chart.yaml
+++ b/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.2
+version: 0.3.3
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-oidc-proxy.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,9 +28,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: https
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: https
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -21,6 +21,9 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}


### PR DESCRIPTION
Bravo this tutorial was excellent, I only needed to change one thing.

(That may be overselling by just a bit, I had to consult more than just a handful of guides to get this working, I can't say with certainty this guide told me **everything I needed to know** but as a part of the landscape of tutorials and guides like this, I have to say this one was the North Star)

This tutorial was the best and most comprehensive, most current of all, most closely approximating the specific setup that I wanted for my home lab Kubernetes instance. I am on Kubernetes 1.22.1 which has deprecated and finally disabled the extensions beta APIs, so I had to adjust the helm chart for kube-oidc-proxy and update to the new networking/v1 structure.

Don't know if you'll want to merge this or not, but it was the only change needed for me. I tripped over a few things because I was so haphazardly following as many different guides as caught my eye, but if I could go back 5 hours and tell myself "focus on this one guide" I think it would be this one.

The only necessary component that your guide positively assumes of the reader, that I actually did not have or know how to do before today, is that you have assumed the reader will have already set up their own Keycloak server and realm, (which I did earlier this morning, that was the other 5 hours already spent long before I came around to this guide series.)

If I could give you 10 stars I would, thanks for writing this guide!