### PR TITLE
Ingress class name

### DIFF
--- a/charts/kube-oidc-proxy/Chart.yaml
+++ b/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/charts/kube-oidc-proxy/Chart.yaml
+++ b/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.2
+version: 0.3.3
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-oidc-proxy.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,9 +28,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: https
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: https
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-oidc-proxy/templates/ingress.yaml
+++ b/charts/kube-oidc-proxy/templates/ingress.yaml
@@ -21,6 +21,9 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}


### PR DESCRIPTION
For Kubernetes Ingress v1 in the networking.k8s.io API, `ingressClassName` is part of the `spec`.

(Today, I needed to use ingressClassName in a v1 ingress, so added this.)